### PR TITLE
Load subr-x for thread-last

### DIFF
--- a/amsreftex.el
+++ b/amsreftex.el
@@ -121,6 +121,7 @@
 (require 'reftex-parse)
 (require 'reftex-dcr)
 (require 'sort)
+(require 'subr-x)
 
 ;;* Vars
 


### PR DESCRIPTION
and fix following byte-compile warnings.

```
In amsreftex-get-bib-name-list:
amsreftex.el:877:10:Warning: mapcar called with 1 argument, but requires 2
amsreftex.el:877:19:Warning: mapcar called with 1 argument, but requires 2
amsreftex.el:878:19:Warning: mapcar called with 1 argument, but requires 2

In end of data:
amsreftex.el:1080:1:Warning: the function ‘thread-last’ is not known to be
    defined.
```